### PR TITLE
optional ROCK_OVERWRITE_INSTANCE_NAME

### DIFF
--- a/k8s_test_harness/harness/lxd.py
+++ b/k8s_test_harness/harness/lxd.py
@@ -61,8 +61,10 @@ class LXDHarness(Harness):
         )
 
     def new_instance(self) -> Instance:
-        instance_id = f"k8s-integration-{os.urandom(3).hex()}-{self.next_id()}"
-
+        instance_id = os.getenv(
+            "ROCK_OVERWRITE_INSTANCE_NAME",
+            f"k8s-integration-{os.urandom(3).hex()}-{self.next_id()}",
+        )
         LOG.debug("Creating instance %s with image %s", instance_id, self.image)
         try:
             stubbornly(retries=3, delay_s=1).exec(

--- a/k8s_test_harness/harness/multipass.py
+++ b/k8s_test_harness/harness/multipass.py
@@ -38,8 +38,10 @@ class MultipassHarness(Harness):
         LOG.debug("Configured Multipass substrate (image %s)", self.image)
 
     def new_instance(self) -> Instance:
-        instance_id = f"k8s-integration-{os.urandom(3).hex()}-{self.next_id()}"
-
+        instance_id = os.getenv(
+            "ROCK_OVERWRITE_INSTANCE_NAME",
+            f"k8s-integration-{os.urandom(3).hex()}-{self.next_id()}",
+        )
         LOG.debug("Creating instance %s with image %s", instance_id, self.image)
         try:
             run(


### PR DESCRIPTION
Added env variable `ROCK_OVERWRITE_INSTANCE_NAME` is useful when working locally on integration tests