### PR TITLE
Update kubernetes helm util function

### DIFF
--- a/k8s_test_harness/util/k8s_util.py
+++ b/k8s_test_harness/util/k8s_util.py
@@ -185,6 +185,7 @@ def get_helm_install_command(
     images: List[HelmImage] = None,
     runAsUser: int = 584792,
     set_configs: List[str] = None,
+    chart_version: str = None,
 ):
     """Creates a helm install command for the given helm chart.
 
@@ -214,6 +215,12 @@ def get_helm_install_command(
         helm_command += [
             "--repo",
             repository,
+        ]
+
+    if chart_version:
+        helm_command += [
+            "--version",
+            chart_version,
         ]
 
     for image in images:

--- a/k8s_test_harness/util/k8s_util.py
+++ b/k8s_test_harness/util/k8s_util.py
@@ -220,11 +220,6 @@ def get_helm_install_command(
         image_split = image.uri.split(":")
         image_name = image_split[0]
 
-        # This helm charts requires setting the image registry separately.
-        parts = image_name.split("/")
-        if len(parts) > 1:
-            image_name = "/".join(parts[1:])
-
         prefix = ""
         if image.prefix:
             prefix = f"{image.prefix}."


### PR DESCRIPTION
Removes image name split logic. This logic was specific for whereabouts, and does not apply for other helm charts.

Adds chart version parameter. In some cases, we need to specify the helm chart version we need to install.