### PR TITLE
Add function scoped harness fixture

### DIFF
--- a/k8s_test_harness/harness/base.py
+++ b/k8s_test_harness/harness/base.py
@@ -43,6 +43,9 @@ class Harness:
 
     name: str
 
+    # Some harnesses cannot effectively cleanup instances (e.g. LocalHarness)
+    supports_cleanup = True
+
     def new_instance(self) -> Instance:
         """Creates a new instance on the infrastructure and returns an object
         which can be used to interact with it.

--- a/k8s_test_harness/harness/local.py
+++ b/k8s_test_harness/harness/local.py
@@ -21,6 +21,10 @@ class LocalHarness(Harness):
 
     name = "local"
 
+    # The local harness cannot perform instance cleanup since there is no form
+    # of sandboxing.
+    supports_cleanup = False
+
     def __init__(self):
         super(LocalHarness, self).__init__()
         self.initialized = False


### PR DESCRIPTION
In some cases, we have identical tests for multiple rock versions. Using a module scoped harness forces us to define separate modules, which seems unnecessary.

This can be avoided by defining a new function scoped harness fixture.