### PR TITLE
Add/extend some K8s-related utilities.

### DIFF
--- a/k8s_test_harness/util/constants.py
+++ b/k8s_test_harness/util/constants.py
@@ -8,6 +8,7 @@ K8S_NS_KUBE_SYSTEM = "kube-system"
 
 K8S_DAEMONSET = "daemonset.apps"
 K8S_DEPLOYMENT = "deployment.apps"
+K8S_STATEFULSET = "statefulset.apps"
 
 K8S_CONDITION_AVAILABLE = "Available"
 K8S_CONDITION_READY = "Ready"

--- a/k8s_test_harness/util/k8s_util.py
+++ b/k8s_test_harness/util/k8s_util.py
@@ -129,9 +129,11 @@ def wait_for_resource(
     name: str,
     namespace: str = constants.K8S_NS_DEFAULT,
     condition: str = constants.K8S_CONDITION_AVAILABLE,
+    retry_times: int = 5,
+    retry_delay_s: int = 10,
 ):
     """Waits for the given resource to reach the given condition."""
-    exec_util.stubbornly(retries=5, delay_s=1).on(instance).exec(
+    exec_util.stubbornly(retries=retry_times, delay_s=retry_delay_s).on(instance).exec(
         [
             "k8s",
             "kubectl",
@@ -142,7 +144,7 @@ def wait_for_resource(
             resource_type,
             name,
             "--timeout",
-            "60s",
+            "1s",
         ]
     )
 
@@ -152,16 +154,30 @@ def wait_for_deployment(
     name: str,
     namespace: str = constants.K8S_NS_DEFAULT,
     condition: str = constants.K8S_CONDITION_AVAILABLE,
+    retry_times: int = 5,
+    retry_delay_s: int = 10,
 ):
     """Waits for the given deployment to reach the given condition."""
-    wait_for_resource(instance, constants.K8S_DEPLOYMENT, name, namespace, condition)
+    wait_for_resource(
+        instance,
+        constants.K8S_DEPLOYMENT,
+        name,
+        namespace=namespace,
+        condition=condition,
+        retry_times=retry_times,
+        retry_delay_s=retry_delay_s,
+    )
 
 
 def wait_for_daemonset(
-    instance: harness.Instance, name: str, namespace: str = constants.K8S_NS_DEFAULT
+    instance: harness.Instance,
+    name: str,
+    namespace: str = constants.K8S_NS_DEFAULT,
+    retry_times: int = 5,
+    retry_delay_s: int = 10,
 ):
     """Waits for the given daemonset to become available."""
-    exec_util.stubbornly(retries=5, delay_s=1).on(instance).exec(
+    exec_util.stubbornly(retries=retry_times, delay_s=retry_delay_s).on(instance).exec(
         [
             "k8s",
             "kubectl",
@@ -172,7 +188,7 @@ def wait_for_daemonset(
             constants.K8S_DAEMONSET,
             name,
             "--timeout",
-            "60s",
+            "1s",
         ]
     )
 

--- a/k8s_test_harness/util/k8s_util.py
+++ b/k8s_test_harness/util/k8s_util.py
@@ -193,6 +193,30 @@ def wait_for_daemonset(
     )
 
 
+def wait_for_statefulset(
+    instance: harness.Instance,
+    name: str,
+    namespace: str = constants.K8S_NS_DEFAULT,
+    retry_times: int = 5,
+    retry_delay_s: int = 10,
+):
+    """Waits for the given daemonset to become available."""
+    exec_util.stubbornly(retries=retry_times, delay_s=retry_delay_s).on(instance).exec(
+        [
+            "k8s",
+            "kubectl",
+            "rollout",
+            "status",
+            "--namespace",
+            namespace,
+            constants.K8S_STATEFULSET,
+            name,
+            "--timeout",
+            "1s",
+        ]
+    )
+
+
 def get_helm_install_command(
     name: str,
     chart_name: str,

--- a/k8s_test_harness/util/k8s_util.py
+++ b/k8s_test_harness/util/k8s_util.py
@@ -130,7 +130,7 @@ def wait_for_resource(
     namespace: str = constants.K8S_NS_DEFAULT,
     condition: str = constants.K8S_CONDITION_AVAILABLE,
     retry_times: int = 5,
-    retry_delay_s: int = 10,
+    retry_delay_s: int = 60,
 ):
     """Waits for the given resource to reach the given condition."""
     exec_util.stubbornly(retries=retry_times, delay_s=retry_delay_s).on(instance).exec(
@@ -155,7 +155,7 @@ def wait_for_deployment(
     namespace: str = constants.K8S_NS_DEFAULT,
     condition: str = constants.K8S_CONDITION_AVAILABLE,
     retry_times: int = 5,
-    retry_delay_s: int = 10,
+    retry_delay_s: int = 60,
 ):
     """Waits for the given deployment to reach the given condition."""
     wait_for_resource(
@@ -174,7 +174,7 @@ def wait_for_daemonset(
     name: str,
     namespace: str = constants.K8S_NS_DEFAULT,
     retry_times: int = 5,
-    retry_delay_s: int = 10,
+    retry_delay_s: int = 60,
 ):
     """Waits for the given daemonset to become available."""
     exec_util.stubbornly(retries=retry_times, delay_s=retry_delay_s).on(instance).exec(
@@ -198,7 +198,7 @@ def wait_for_statefulset(
     name: str,
     namespace: str = constants.K8S_NS_DEFAULT,
     retry_times: int = 5,
-    retry_delay_s: int = 10,
+    retry_delay_s: int = 60,
 ):
     """Waits for the given daemonset to become available."""
     exec_util.stubbornly(retries=retry_times, delay_s=retry_delay_s).on(instance).exec(

--- a/k8s_test_harness/util/platform_util.py
+++ b/k8s_test_harness/util/platform_util.py
@@ -8,7 +8,6 @@ for ROCK testing."""
 
 import platform
 
-
 ROCKCRAFT_PLATFORM_AMD64 = "amd64"
 ROCKCRAFT_PLATFORM_I386 = "i386"
 ROCKCRAFT_PLATFORM_ARM64 = "arm64"
@@ -17,12 +16,12 @@ ROCKCRAFT_PLATFORM_ARM64 = "arm64"
 _PYTHON_MACHINE_TO_ROCKCRAFT_PLATFORM_ARCHITECTURE_MAP = {
     "x86": ROCKCRAFT_PLATFORM_I386,
     "x86_64": ROCKCRAFT_PLATFORM_AMD64,
-    "arm64": ROCKCRAFT_PLATFORM_ARM64
+    "arm64": ROCKCRAFT_PLATFORM_ARM64,
 }
 
 
 def get_current_rockcraft_platform_architecture() -> str:
-    """ Returns a string containing the rockcraft-specific platform
+    """Returns a string containing the rockcraft-specific platform
     architecture label of the currently running process.
 
     https://documentation.ubuntu.com/rockcraft/en/latest/reference/rockcraft.yaml/#platforms
@@ -33,13 +32,12 @@ def get_current_rockcraft_platform_architecture() -> str:
 
     machine = platform.machine()
     if not machine:
-        raise OSError(
-            "Failed to get current platform through `platform.machine()`.")
+        raise OSError("Failed to get current platform through `platform.machine()`.")
 
     if machine not in _PYTHON_MACHINE_TO_ROCKCRAFT_PLATFORM_ARCHITECTURE_MAP:
         raise ValueError(
             f"Unknown platform machine type '{machine}'. Known values are: "
-            f"{list(_PYTHON_MACHINE_TO_ROCKCRAFT_PLATFORM_ARCHITECTURE_MAP)}")
+            f"{list(_PYTHON_MACHINE_TO_ROCKCRAFT_PLATFORM_ARCHITECTURE_MAP)}"
+        )
 
     return _PYTHON_MACHINE_TO_ROCKCRAFT_PLATFORM_ARCHITECTURE_MAP[machine]
-


### PR DESCRIPTION
This patch notably:

- extends the various `k8s_utils.wait_for_*()` functions with configurable retry times/period arguments
- adds an explicit `wait_for_statefulset` function
- formating fixes to `platform_util` module
- add decorator to `kubectl describe` relevant resources in case any `wait_for_*()` functions fail