### PR TITLE
Increase node timeout

### DIFF
--- a/k8s_test_harness/util/k8s_util.py
+++ b/k8s_test_harness/util/k8s_util.py
@@ -61,7 +61,7 @@ def wait_until_k8s_ready(
     for instance in instances:
         host = hostname(instance)
         result = (
-            exec_util.stubbornly(retries=15, delay_s=5)
+            exec_util.stubbornly(retries=30, delay_s=5)
             .on(control_node)
             .until(lambda p: " Ready" in p.stdout.decode())
             .exec(["k8s", "kubectl", "get", "node", host, "--no-headers"])


### PR DESCRIPTION
We're currently waiting about 75s for k8s nodes to become available.

In nested environments, this timeout can be occasionally exceeded. For this reason, we'll double the amount of retries.