### PR TITLE
k8s_util: Describe resources from all namespaces

### DIFF
--- a/k8s_test_harness/util/k8s_util.py
+++ b/k8s_test_harness/util/k8s_util.py
@@ -42,7 +42,8 @@ def describe_resources_on_error(resource_type: str):
                 return fun(instance, *args, **kwargs)
             except Exception:
                 proc = instance.exec(
-                    ["k8s", "kubectl", "describe", resource_type], capture_output=True
+                    ["k8s", "kubectl", "describe", "-A", resource_type],
+                    capture_output=True,
                 )
                 LOG.info(
                     f"### All current '{resource_type}' definitions: "


### PR DESCRIPTION
On error, we describe resources. However, we only describe the ones in the default namespace, which isn't typically used in tests.

Instead, we could describe the resources from all namespaces.