### PR TITLE
feature: add fips testing utilities

### DIFF
--- a/k8s_test_harness/__init__.py
+++ b/k8s_test_harness/__init__.py
@@ -1,4 +1,4 @@
 #
-# Copyright 2024 Canonical, Ltd.
+# Copyright 2025 Canonical, Ltd.
 # See LICENSE file for licensing details
 #

--- a/k8s_test_harness/config.py
+++ b/k8s_test_harness/config.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 Canonical, Ltd.
+# Copyright 2025 Canonical, Ltd.
 # See LICENSE file for licensing details
 #
 import os

--- a/k8s_test_harness/harness/__init__.py
+++ b/k8s_test_harness/harness/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 Canonical, Ltd.
+# Copyright 2025 Canonical, Ltd.
 # See LICENSE file for licensing details
 #
 from k8s_test_harness.harness.base import Harness, HarnessError, Instance

--- a/k8s_test_harness/harness/base.py
+++ b/k8s_test_harness/harness/base.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 Canonical, Ltd.
+# Copyright 2025 Canonical, Ltd.
 # See LICENSE file for licensing details
 #
 import subprocess

--- a/k8s_test_harness/harness/juju.py
+++ b/k8s_test_harness/harness/juju.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 Canonical, Ltd.
+# Copyright 2025 Canonical, Ltd.
 # See LICENSE file for licensing details
 #
 import json

--- a/k8s_test_harness/harness/local.py
+++ b/k8s_test_harness/harness/local.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 Canonical, Ltd.
+# Copyright 2025 Canonical, Ltd.
 # See LICENSE file for licensing details
 #
 

--- a/k8s_test_harness/harness/lxd.py
+++ b/k8s_test_harness/harness/lxd.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 Canonical, Ltd.
+# Copyright 2025 Canonical, Ltd.
 # See LICENSE file for licensing details
 #
 import logging

--- a/k8s_test_harness/harness/multipass.py
+++ b/k8s_test_harness/harness/multipass.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 Canonical, Ltd.
+# Copyright 2025 Canonical, Ltd.
 # See LICENSE file for licensing details
 #
 import logging

--- a/k8s_test_harness/lxd-profile.yaml
+++ b/k8s_test_harness/lxd-profile.yaml
@@ -1,5 +1,5 @@
 ##
-## Copyright 2024 Canonical, Ltd.
+## Copyright 2025 Canonical, Ltd.
 ## See LICENSE file for licensing details
 ##
 description: "LXD profile for Canonical Kubernetes"

--- a/k8s_test_harness/plugin.py
+++ b/k8s_test_harness/plugin.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 Canonical, Ltd.
+# Copyright 2025 Canonical, Ltd.
 # See LICENSE file for licensing details
 #
 import logging

--- a/k8s_test_harness/templates/bootstrap-session.yaml
+++ b/k8s_test_harness/templates/bootstrap-session.yaml
@@ -1,5 +1,5 @@
 ##
-## Copyright 2024 Canonical, Ltd.
+## Copyright 2025 Canonical, Ltd.
 ## See LICENSE file for licensing details
 ##
 

--- a/k8s_test_harness/util/__init__.py
+++ b/k8s_test_harness/util/__init__.py
@@ -1,4 +1,4 @@
 #
-# Copyright 2024 Canonical, Ltd.
+# Copyright 2025 Canonical, Ltd.
 # See LICENSE file for licensing details
 #

--- a/k8s_test_harness/util/constants.py
+++ b/k8s_test_harness/util/constants.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 Canonical, Ltd.
+# Copyright 2025 Canonical, Ltd.
 # See LICENSE file for licensing details
 #
 

--- a/k8s_test_harness/util/docker_util.py
+++ b/k8s_test_harness/util/docker_util.py
@@ -183,7 +183,9 @@ def get_image_version(image):
     return process.stdout.strip()
 
 
-def run_entrypoint_and_assert(image, entrypoint, expect_stdout_contains=None, expect_stderr_contains=None):
+def run_entrypoint_and_assert(
+    image, entrypoint, expect_stdout_contains=None, expect_stderr_contains=None
+):
     """Runs the given entrypoint in the given image and asserts that it succeeds.
 
     If expect_stdout_contains is provided, also asserts that the given string

--- a/k8s_test_harness/util/docker_util.py
+++ b/k8s_test_harness/util/docker_util.py
@@ -183,18 +183,24 @@ def get_image_version(image):
     return process.stdout.strip()
 
 
-def run_entrypoint_and_assert(image, entrypoint, expect_stdout_contains=None):
+def run_entrypoint_and_assert(image, entrypoint, expect_stdout_contains=None, expect_stderr_contains=None):
     """Runs the given entrypoint in the given image and asserts that it succeeds.
 
     If expect_stdout_contains is provided, also asserts that the given string
-    is contained in the stdout.
+    is contained in the stdout. Similarly for expect_stderr_contains.
     """
     entry = shlex.split(entrypoint) if isinstance(entrypoint, str) else entrypoint
     process = run_in_docker(image, entry, check_exit_code=False)
     assert (
         process.returncode == 0
     ), f"Failed to run {entry} in image {image}, stderr: {process.stderr}"
+
     if expect_stdout_contains:
         assert (
             expect_stdout_contains in process.stdout
         ), f"Expected '{expect_stdout_contains}' in stdout for {entry} in image {image}, stdout: {process.stdout}"
+
+    if expect_stderr_contains:
+        assert (
+            expect_stderr_contains in process.stderr
+        ), f"Expected '{expect_stderr_contains}' in stderr for {entry} in image {image}, stderr: {process.stderr}"

--- a/k8s_test_harness/util/docker_util.py
+++ b/k8s_test_harness/util/docker_util.py
@@ -9,7 +9,7 @@ import os
 import shlex
 import stat
 import subprocess
-from typing import List
+from typing import List, Optional, Union
 
 LOG = logging.getLogger(__name__)
 
@@ -184,7 +184,10 @@ def get_image_version(image):
 
 
 def run_entrypoint_and_assert(
-    image, entrypoint, expect_stdout_contains=None, expect_stderr_contains=None
+    image: str,
+    entrypoint: Union[str, List[str]],
+    expect_stdout_contains: Optional[str]=None,
+    expect_stderr_contains: Optional[str]=None
 ):
     """Runs the given entrypoint in the given image and asserts that it succeeds.
 
@@ -195,7 +198,7 @@ def run_entrypoint_and_assert(
     process = run_in_docker(image, entry, check_exit_code=False)
     assert (
         process.returncode == 0
-    ), f"Failed to run {entry} in image {image}, stderr: {process.stderr}"
+    ), f"Failed to run `{shlex.join(entry)}` in image {image}, {process.stdout=} {process.stderr=}"
 
     if expect_stdout_contains:
         assert (

--- a/k8s_test_harness/util/env_util.py
+++ b/k8s_test_harness/util/env_util.py
@@ -225,13 +225,14 @@ def resolve_image(
         return f"{image_path}:{version}"
 
 
-def image_versions_in_repo(repo_path: pathlib.Path) -> List[str]:
+def image_versions_in_repo(image_name: str, repo_path: pathlib.Path) -> List[str]:
     """Returns a list of all ROCK versions found in rockcraft.yaml files
     in the given repository path.
 
+    :param image_name: Name of the ROCK to scan for.
     :param repo_path: Path to the root of the repository to scan.
     :returns: List of ROCK versions found.
     """
     all_rockcrafts = repo_path.glob("**/rockcraft.yaml")
     yamls = [yaml.safe_load(rock.read_bytes()) for rock in all_rockcrafts]
-    return [rock["version"] for rock in yamls]
+    return [rock["version"] for rock in yamls if rock["name"] == image_name]

--- a/k8s_test_harness/util/env_util.py
+++ b/k8s_test_harness/util/env_util.py
@@ -209,22 +209,6 @@ def get_build_meta_info_for_rock_version(
     return matches[0]
 
 
-def resolve_image(
-    name: str, version: str, image_path: Optional[str] = None, arch: str = "amd64"
-) -> str:
-    """Resolves the image for the given ROCK name, version, and architecture.
-
-    :returns: the resolved image string if found in the built ROCKs metadata,
-        otherwise returns the default image string of the form "{image_path}:{version}".
-    """
-    image_path = image_path or f"github.com/canonical/{name}"
-    try:
-        rock = get_build_meta_info_for_rock_version(name, version, arch)
-        return rock.image
-    except OSError:
-        return f"{image_path}:{version}"
-
-
 def image_versions_in_repo(image_name: str, repo_path: pathlib.Path) -> List[str]:
     """Returns a list of all ROCK versions found in rockcraft.yaml files
     in the given repository path.

--- a/k8s_test_harness/util/env_util.py
+++ b/k8s_test_harness/util/env_util.py
@@ -13,6 +13,7 @@ https://github.com/canonical/k8s-workflows/blob/main/.github/workflows/build_roc
 
 import json
 import os
+import pathlib
 from dataclasses import dataclass
 from typing import Dict, List
 
@@ -224,7 +225,7 @@ def resolve_image(
         return f"{image_path}:{version}"
 
 
-def image_versions_in_repo(repo_path) -> List[str]:
+def image_versions_in_repo(repo_path: pathlib.Path) -> List[str]:
     """Returns a list of all ROCK versions found in rockcraft.yaml files
     in the given repository path.
 

--- a/k8s_test_harness/util/env_util.py
+++ b/k8s_test_harness/util/env_util.py
@@ -15,7 +15,7 @@ import json
 import os
 import pathlib
 from dataclasses import dataclass
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 import yaml
 
@@ -210,7 +210,7 @@ def get_build_meta_info_for_rock_version(
 
 
 def resolve_image(
-    name: str, version: str, image_path: str | None = None, arch: str = "amd64"
+    name: str, version: str, image_path: Optional[str] = None, arch: str = "amd64"
 ) -> str:
     """Resolves the image for the given ROCK name, version, and architecture.
 

--- a/k8s_test_harness/util/env_util.py
+++ b/k8s_test_harness/util/env_util.py
@@ -214,7 +214,8 @@ def resolve_image(
     """Resolves the image for the given ROCK name, version, and architecture.
 
     :returns: the resolved image string if found in the built ROCKs metadata,
-        otherwise returns the default image string of the form"""
+        otherwise returns the default image string of the form "{image_path}:{version}".
+    """
     image_path = image_path or f"github.com/canonical/{name}"
     try:
         rock = get_build_meta_info_for_rock_version(name, version, arch)

--- a/k8s_test_harness/util/env_util.py
+++ b/k8s_test_harness/util/env_util.py
@@ -15,7 +15,7 @@ import json
 import os
 import pathlib
 from dataclasses import dataclass
-from typing import Dict, List, Optional
+from typing import Dict, List
 
 import yaml
 

--- a/k8s_test_harness/util/exec_util.py
+++ b/k8s_test_harness/util/exec_util.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 Canonical, Ltd.
+# Copyright 2025 Canonical, Ltd.
 # See LICENSE file for licensing details
 #
 import logging

--- a/k8s_test_harness/util/fips_util.py
+++ b/k8s_test_harness/util/fips_util.py
@@ -1,0 +1,21 @@
+#
+# Copyright 2025 Canonical, Ltd.
+# See LICENSE file for licensing details
+#
+
+
+def is_fips_rock(rockcraft_yaml: str) -> bool:
+    """Returns True if the given rockcraft yaml indicates a FIPS ROCK."""
+    return "fips" in rockcraft_yaml.lower()
+
+
+def fips_expectations(rockcraft_yaml: str, GOFIPS: int) -> tuple:
+    """
+    Return (expected_returncode, expected_error) for a given rockcraft yaml and GOFIPS value.
+    """
+    if is_fips_rock(rockcraft_yaml):
+        # fipsed ROCKs should fail if GOFIPS set on a non-fips system
+        # since the modified Go toolchain checks for a FIPS-capable crypto backend.
+        return (2, "FIPS") if GOFIPS == 1 else (0, "")
+    # non-FIPS ROCKs should not care about GOFIPS setting and always succeed
+    return 0, ""

--- a/k8s_test_harness/util/k8s_util.py
+++ b/k8s_test_harness/util/k8s_util.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 Canonical, Ltd.
+# Copyright 2025 Canonical, Ltd.
 # See LICENSE file for licensing details
 #
 

--- a/k8s_test_harness/util/net_util.py
+++ b/k8s_test_harness/util/net_util.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 Canonical, Ltd.
+# Copyright 2025 Canonical, Ltd.
 # See LICENSE file for licensing details
 #
 

--- a/k8s_test_harness/util/platform_util.py
+++ b/k8s_test_harness/util/platform_util.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 Canonical, Ltd.
+# Copyright 2025 Canonical, Ltd.
 # See LICENSE file for licensing details
 #
 


### PR DESCRIPTION
**New utility functions:**

* Added `is_fips_rock` and `fips_expectations` functions in `k8s_test_harness/util/fips_util.py` to detect FIPS-enabled ROCKs and determine expected behavior based on the GOFIPS environment variable.
* Added `run_entrypoint_and_assert` to `k8s_test_harness/util/docker_util.py` for running image entrypoints and asserting expected output, improving Docker image validation in tests.
* Added `image_versions_in_repo` to `k8s_test_harness/util/env_util.py` to scan a repository for all ROCK versions of a given image by parsing `rockcraft.yaml` files.

